### PR TITLE
Use latest online version of jQuery

### DIFF
--- a/Javascript/main.html
+++ b/Javascript/main.html
@@ -3,7 +3,7 @@
 
 	<head>
     <title>Simplify an SVG</title>
-		<script type="text/javascript" src="jquery.js"></script>
+		<script type="text/javascript" src="https://code.jquery.com/jquery-3.6.0.slim.min.js"></script>
     <script type='text/javascript' src='svg-optimiser.js'></script>
 		<script type='text/javascript' src='optimiser_tests.js'></script>
     <link type="text/css" rel="stylesheet" href="main.css" />


### PR DESCRIPTION
Since `jquery.js` isn't actually included with this project, linking to the latest version from the CDN makes the browser tool work out of the box.